### PR TITLE
make: upload CloudFormation templates to s3 as public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+S3_CP_ARGS=aws s3 cp --acl public-read
+
 .PHONY: cloudformation
 cloudformation:
-	aws s3 cp templates/firehose.yaml s3://observeinc/cloudformation/firehose-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/firehose.yaml s3://observeinc/cloudformation/firehose-latest.yaml
+	$(S3_CP_ARGS) templates/firehose.yaml s3://observeinc/cloudformation/firehose-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/firehose.yaml s3://observeinc/cloudformation/firehose-latest.yaml
 
 .PHONY: changelog
 changelog:


### PR DESCRIPTION
Ensures templates are uploaded to S3 as public objects

See https://github.com/observeinc/cloudformation-aws-collection/pull/5